### PR TITLE
Update dependency versions

### DIFF
--- a/.github/workflows/test_ufbt.yml
+++ b/.github/workflows/test_ufbt.yml
@@ -51,7 +51,7 @@ jobs:
           app-dir: 'test'
 
       - name: Upload app artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fap-${{ steps.build-app.outputs.suffix }}
           path: ${{ steps.build-app.outputs.fap-artifacts }}

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       if: inputs.skip-setup == 'false'
       with:
         python-version: '3.11'
@@ -158,7 +158,7 @@ runs:
         echo "deployed-version=`cat ${{ fromJSON(steps.ufbt-status.outputs.json).toolchain_dir }}/*/VERSION 2>/dev/null || echo 0`" >> $GITHUB_OUTPUT
         
     - name: Cache toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: steps.get-tooclhain-version.outputs.required-version != steps.get-tooclhain-version.outputs.deployed-version
       with:
         path: ${{ fromJSON(steps.ufbt-status.outputs.json).toolchain_dir }}


### PR DESCRIPTION
Updates dependencies to use Node20-based actions, as per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/. This resolves Node16 deprecation warnings occurring for any project using ufbt.

Untested, let's let the CI test it.

Fixes #7.